### PR TITLE
DEV-41: integrate JSDoc plugin and enhance type documentation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'eslint-config-prettier',
     'prettier',
+    'plugin:jsdoc/recommended-typescript',
   ],
   settings: {
     react: { version: 'detect' },
@@ -33,8 +34,27 @@ module.exports = {
       },
     ],
     'react/react-in-jsx-scope': 'off',
+
+    'jsdoc/require-jsdoc': [
+      2,
+      {
+        contexts: [
+          'TSInterfaceDeclaration',
+          'TSTypeAliasDeclaration',
+          'TSPropertySignature',
+          'TSMethodSignature',
+          'TSIndexSignature',
+          'TSCallSignatureDeclaration',
+          'TSEnumDeclaration',
+          'TSEnumMember',
+          'TSDeclareFunction',
+        ],
+      },
+    ],
+    'jsdoc/require-param': 0,
+    'jsdoc/require-returns': 0,
   },
   ignorePatterns: ['dist', '.eslintrc.cjs', 'vite.config.ts'],
   parser: '@typescript-eslint/parser',
-  plugins: ['react-refresh', 'import'],
+  plugins: ['react-refresh', 'import', 'jsdoc'],
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-jsdoc": "^62.8.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.2",

--- a/src/app/providers/theme/ThemeProvider.types.ts
+++ b/src/app/providers/theme/ThemeProvider.types.ts
@@ -1,5 +1,11 @@
 import type { ReactNode } from 'react';
 
+/**
+ * Props for the app theme provider wrapper.
+ */
 export interface CustomThemeProviderProps {
+  /**
+   * React subtree that receives the theme context.
+   */
   children: ReactNode;
 }

--- a/src/app/store/answers/createAnswersSlice.types.ts
+++ b/src/app/store/answers/createAnswersSlice.types.ts
@@ -1,12 +1,39 @@
 import type { AnswersByQuestionId } from '@/entities/Question';
 
+/**
+ * Store slice for the current quiz attempt's answers and navigation.
+ */
 export interface AnswersSlice {
+  /**
+   * Currently selected answer option keys (e.g. "answer_a") for the current question.
+   */
   checkedAnswers: string[];
+  /**
+   * Zero-based index of the question being shown.
+   */
   currentQuestionIndex: number;
+  /**
+   * Map of question id to array of selected answer keys (e.g. answer_a) per question.
+   */
   userAnswers: AnswersByQuestionId;
+  /**
+   * Clears the current question's selected answers.
+   */
   clearCheckedAnswers: () => void;
+  /**
+   * Adds or removes an answer key in checkedAnswers.
+   */
   toggleAnswer: (userAnswer: string) => void;
+  /**
+   * Advances to the next question.
+   */
   incrementQuestionIndex: () => void;
+  /**
+   * Saves current checkedAnswers for the given question id and clears them.
+   */
   updateUserAnswers: (answers: string[], questionId: number) => void;
+  /**
+   * Resets the current question index (e.g. for a new game).
+   */
   resetQuestionIndex: () => void;
 }

--- a/src/app/store/category/createCategorySlice.types.ts
+++ b/src/app/store/category/createCategorySlice.types.ts
@@ -1,8 +1,23 @@
 import type { CategoryModel } from '@/entities/Category';
 
+/**
+ * Store slice for quiz categories from QuizAPI.
+ */
 export interface CategorySlice {
+  /**
+   * List of category id and name.
+   */
   categories: CategoryModel[];
+  /**
+   * Whether categories are being fetched.
+   */
   isLoading: boolean;
+  /**
+   * Whether the last categories request failed.
+   */
   isError: boolean;
+  /**
+   * Fetches categories from the API and updates the slice.
+   */
   requestCategories: () => Promise<void>;
 }

--- a/src/app/store/game/createGameSlice.types.ts
+++ b/src/app/store/game/createGameSlice.types.ts
@@ -4,10 +4,28 @@ import type {
   AnswersByQuestionId,
 } from '@/entities/Question';
 
+/**
+ * Store slice for questions and quiz run state.
+ */
 export interface GameSlice {
+  /**
+   * List of questions for the current game.
+   */
   questions: QuestionModel[];
+  /**
+   * Whether questions are being fetched.
+   */
   isLoading: boolean;
+  /**
+   * Whether the last questions request failed.
+   */
   isError: boolean;
+  /**
+   * Map of question id to array of correct answer keys (from API).
+   */
   correctAnswers: AnswersByQuestionId;
+  /**
+   * Fetches questions by category/difficulty/limit and updates the slice.
+   */
   requestQuestions: (params: RequestQuestionsParams) => Promise<void>;
 }

--- a/src/app/store/rootStore.types.ts
+++ b/src/app/store/rootStore.types.ts
@@ -4,12 +4,27 @@ import type { AnswersSlice } from './answers';
 import type { CategorySlice } from './category';
 import type { GameSlice } from './game';
 
+/**
+ * Root Zustand store combining game, answers, and category slices.
+ */
 export interface AppStore {
+  /**
+   * Slice for quiz questions, loading state, and correct answers.
+   */
   game: GameSlice;
+  /**
+   * Slice for user selections, current question index, and answer actions.
+   */
   answers: AnswersSlice;
+  /**
+   * Slice for categories list and fetch state.
+   */
   category: CategorySlice;
 }
 
+/**
+ * Zustand state creator with Immer middleware for immutable updates.
+ */
 export type ImmerStateCreator<T> = StateCreator<
   AppStore,
   [['zustand/immer', never]],

--- a/src/entities/Category/api/getCategories/getCategories.types.ts
+++ b/src/entities/Category/api/getCategories/getCategories.types.ts
@@ -1,4 +1,13 @@
+/**
+ * Category item from QuizAPI categories endpoint.
+ */
 export interface CategoryModel {
+  /**
+   * Category id.
+   */
   id: number;
+  /**
+   * Category display name.
+   */
   name: string;
 }

--- a/src/entities/Question/api/getQuestions/getQuestions.types.ts
+++ b/src/entities/Question/api/getQuestions/getQuestions.types.ts
@@ -1,7 +1,19 @@
 import type { Difficulty } from '../../model/types';
 
+/**
+ * Parameters for the QuizAPI get questions request.
+ */
 export interface RequestQuestionsParams {
-  category: string | undefined;
-  difficulty: Difficulty | undefined;
+  /**
+   * Optional QuizAPI category name filter.
+   */
+  category?: string;
+  /**
+   * Optional difficulty filter.
+   */
+  difficulty?: Difficulty;
+  /**
+   * Optional maximum number of questions to return.
+   */
   limit?: number;
 }

--- a/src/entities/Question/model/types.ts
+++ b/src/entities/Question/model/types.ts
@@ -1,40 +1,133 @@
+/**
+ * QuizAPI difficulty level.
+ */
 export type Difficulty = 'Easy' | 'Medium' | 'Hard';
 
+/**
+ * QuizAPI string flag indicating if an answer option is correct.
+ */
 export type IsCorrect = 'true' | 'false';
 
+/**
+ * QuizAPI answer options; keys answer_a through answer_f, value null if unused.
+ */
 export interface Answers {
+  /**
+   * Answer option A text, or null if unused.
+   */
   answer_a: null | string;
+  /**
+   * Answer option B text, or null if unused.
+   */
   answer_b: null | string;
+  /**
+   * Answer option C text, or null if unused.
+   */
   answer_c: null | string;
+  /**
+   * Answer option D text, or null if unused.
+   */
   answer_d: null | string;
+  /**
+   * Answer option E text, or null if unused.
+   */
   answer_e: null | string;
+  /**
+   * Answer option F text, or null if unused.
+   */
   answer_f: null | string;
 }
 
+/**
+ * QuizAPI flags for which options are correct (answer_a_correct through answer_f_correct).
+ */
 export interface CorrectAnswers {
+  /**
+   * QuizAPI flag for answer_a correctness.
+   */
   [answer_a_correct: string]: IsCorrect;
+  /**
+   * QuizAPI flag for answer_b correctness.
+   */
   answer_b_correct: IsCorrect;
+  /**
+   * QuizAPI flag for answer_c correctness.
+   */
   answer_c_correct: IsCorrect;
+  /**
+   * QuizAPI flag for answer_d correctness.
+   */
   answer_d_correct: IsCorrect;
+  /**
+   * QuizAPI flag for answer_e correctness.
+   */
   answer_e_correct: IsCorrect;
+  /**
+   * QuizAPI flag for answer_f correctness.
+   */
   answer_f_correct: IsCorrect;
 }
 
+/**
+ * Map from question id to array of correct answer keys (e.g. ["answer_a"]).
+ */
 export interface AnswersByQuestionId {
+  /**
+   * Array of selected or correct answer keys for the question.
+   */
   [questionId: number]: string[];
 }
 
+/**
+ * Single question from QuizAPI.
+ */
 export interface QuestionModel {
+  /**
+   * Question id.
+   */
   id: number;
+  /**
+   * Question text.
+   */
   question: string;
+  /**
+   * Optional description of the question.
+   */
   description: null | string;
+  /**
+   * Answer options object (answer_a through answer_f).
+   */
   answers: Answers;
+  /**
+   * Whether more than one option can be correct.
+   */
   multiple_correct_answers: IsCorrect;
+  /**
+   * QuizAPI correct flags object for each option.
+   */
   correct_answers: CorrectAnswers;
+  /**
+   * Single correct answer key when applicable.
+   */
   correct_answer: null | string;
+  /**
+   * Answer explanation.
+   */
   explanation: null | string;
+  /**
+   * Optional hint for the question.
+   */
   tip: null | string;
+  /**
+   * Topic tags.
+   */
   tags: string[];
+  /**
+   * Category name.
+   */
   category: string;
+  /**
+   * Difficulty level.
+   */
   difficulty: Difficulty;
 }

--- a/src/pages/Category/ui/CategoryList/CategoryList.types.ts
+++ b/src/pages/Category/ui/CategoryList/CategoryList.types.ts
@@ -1,5 +1,11 @@
 import { CategoryModel } from '@/entities/Category';
 
+/**
+ * Props for the category list component.
+ */
 export interface CategoryListProps {
+  /**
+   * List of categories to display.
+   */
   categories: CategoryModel[];
 }

--- a/src/pages/Game/model/useGamePage/useGamePage.ts
+++ b/src/pages/Game/model/useGamePage/useGamePage.ts
@@ -55,8 +55,14 @@ export const useGamePage = () => {
   };
 
   const { categoryName, difficultyLevel } = useParams<{
-    categoryName: string | undefined;
-    difficultyLevel: Difficulty | undefined;
+    /**
+     * Route param for the selected category name.
+     */
+    categoryName?: string;
+    /**
+     * Route param for the selected difficulty (e.g. Easy, Medium, Hard).
+     */
+    difficultyLevel?: Difficulty;
   }>();
 
   useEffect(() => {

--- a/src/pages/Game/ui/AnswersList/AnswersList.types.ts
+++ b/src/pages/Game/ui/AnswersList/AnswersList.types.ts
@@ -1,7 +1,19 @@
 import { Answers } from '@/entities/Question';
 
+/**
+ * Props for the list of answer options.
+ */
 export interface AnswersListProps {
+  /**
+   * QuizAPI answers object (answer_a through answer_f).
+   */
   answers: Answers;
+  /**
+   * Currently selected answer keys for this question.
+   */
   checkedAnswers: string[];
+  /**
+   * Callback when user toggles an answer; receives the answer key.
+   */
   onAnswerToggle: (userAnswer: string) => void;
 }

--- a/src/pages/Game/ui/ToggleAnswerButton/ToggleAnswerButton.types.ts
+++ b/src/pages/Game/ui/ToggleAnswerButton/ToggleAnswerButton.types.ts
@@ -1,5 +1,17 @@
+/**
+ * Props for a single answer toggle button.
+ */
 export interface ToggleAnswerButtonProps {
+  /**
+   * Answer option text to display.
+   */
   answer: string;
+  /**
+   * Whether this option is currently selected.
+   */
   isChecked: boolean;
+  /**
+   * Callback when the option is toggled; receives the answer key.
+   */
   onToggle: (userAnswer: string) => void;
 }

--- a/src/shared/ui/parallax-text/parallax-text.types.ts
+++ b/src/shared/ui/parallax-text/parallax-text.types.ts
@@ -1,4 +1,13 @@
+/**
+ * Props for the parallax text component.
+ */
 export interface ParallaxProps {
+  /**
+   * Text content to animate.
+   */
   children: string;
+  /**
+   * Optional scroll velocity multiplier for the parallax effect.
+   */
   baseVelocity?: number;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,10 +1,25 @@
 /// <reference types="vite/client" />
 
+/**
+ * Vite-injected environment variables available at build time.
+ */
 interface ImportMetaEnv {
+  /**
+   * Base URL for the QuizAPI (e.g. https://quizapi.io/api/v1).
+   */
   VITE_API_BASE_URL: string;
+  /**
+   * API key for authenticating with QuizAPI.
+   */
   VITE_API_KEY: string;
 }
 
+/**
+ * Vite's augmented import.meta object.
+ */
 interface ImportMeta {
+  /**
+   * Read-only access to ImportMetaEnv.
+   */
   readonly env: ImportMetaEnv;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,6 +294,22 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
+"@es-joy/jsdoccomment@~0.84.0":
+  version "0.84.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.84.0.tgz#4d798d33207825dd1d85babbfbacc3a76c3ba634"
+  integrity sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==
+  dependencies:
+    "@types/estree" "^1.0.8"
+    "@typescript-eslint/types" "^8.54.0"
+    comment-parser "1.4.5"
+    esquery "^1.7.0"
+    jsdoc-type-pratt-parser "~7.1.1"
+
+"@es-joy/resolve.exports@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz#fe541a68aa080255f798c8561714ac8fad72cdd5"
+  integrity sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==
+
 "@esbuild/aix-ppc64@0.21.5":
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
@@ -765,6 +781,11 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
+"@sindresorhus/base62@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/base62/-/base62-1.0.0.tgz#c47c42410e5212e4fa4657670e118ddfba39acd6"
+  integrity sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==
+
 "@tybys/wasm-util@^0.10.0":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
@@ -927,6 +948,11 @@
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.18.0.tgz#b90a57ccdea71797ffffa0321e744f379ec838c9"
   integrity sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==
+
+"@typescript-eslint/types@^8.54.0":
+  version "8.57.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.57.0.tgz#4fa5385ffd1cd161fa5b9dce93e0493d491b8dc6"
+  integrity sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==
 
 "@typescript-eslint/typescript-estree@7.18.0":
   version "7.18.0"
@@ -1215,7 +1241,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.15.0, acorn@^8.9.0:
+acorn@^8.15.0, acorn@^8.16.0, acorn@^8.9.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -1265,6 +1291,11 @@ ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+are-docs-informative@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/are-docs-informative/-/are-docs-informative-0.0.2.tgz#387f0e93f5d45280373d387a59d34c96db321963"
+  integrity sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -1553,6 +1584,11 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+comment-parser@1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.4.5.tgz#6c595cd090737a1010fe5ff40d86e1d21b7bd6ce"
+  integrity sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1632,7 +1668,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0:
+debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1958,6 +1994,26 @@ eslint-plugin-import@^2.29.1:
     string.prototype.trimend "^1.0.9"
     tsconfig-paths "^3.15.0"
 
+eslint-plugin-jsdoc@^62.8.0:
+  version "62.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.8.0.tgz#61a5d3b5378b389edd9f2d0682d09103a89c6889"
+  integrity sha512-hu3r9/6JBmPG6wTcqtYzgZAnjEG2eqRUATfkFscokESg1VDxZM21ZaMire0KjeMwfj+SXvgB4Rvh5LBuesj92w==
+  dependencies:
+    "@es-joy/jsdoccomment" "~0.84.0"
+    "@es-joy/resolve.exports" "1.2.0"
+    are-docs-informative "^0.0.2"
+    comment-parser "1.4.5"
+    debug "^4.4.3"
+    escape-string-regexp "^4.0.0"
+    espree "^11.1.0"
+    esquery "^1.7.0"
+    html-entities "^2.6.0"
+    object-deep-merge "^2.0.0"
+    parse-imports-exports "^0.2.4"
+    semver "^7.7.4"
+    spdx-expression-parse "^4.0.0"
+    to-valid-identifier "^1.0.0"
+
 eslint-plugin-jsx-a11y@^6.8.0:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz#d2812bb23bf1ab4665f1718ea442e8372e638483"
@@ -2034,6 +2090,11 @@ eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
+eslint-visitor-keys@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
+  integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
+
 eslint@^8.57.0:
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
@@ -2078,6 +2139,15 @@ eslint@^8.57.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
+espree@^11.1.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-11.2.0.tgz#01d5e47dc332aaba3059008362454a8cc34ccaa5"
+  integrity sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==
+  dependencies:
+    acorn "^8.16.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^5.0.1"
+
 espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
@@ -2087,7 +2157,7 @@ espree@^9.6.0, espree@^9.6.1:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esquery@^1.4.2:
+esquery@^1.4.2, esquery@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.7.0.tgz#08d048f261f0ddedb5bae95f46809463d9c9496d"
   integrity sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==
@@ -2447,6 +2517,11 @@ hoist-non-react-statics@^3.3.1:
   dependencies:
     react-is "^16.7.0"
 
+html-entities@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.6.0.tgz#7c64f1ea3b36818ccae3d3fb48b6974208e984f8"
+  integrity sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==
+
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
@@ -2740,6 +2815,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jsdoc-type-pratt-parser@~7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz#c67be3c812aaf1405bef3e965e8c3db50a5cad1b"
+  integrity sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==
+
 jsesc@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
@@ -2988,6 +3068,11 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
+object-deep-merge@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/object-deep-merge/-/object-deep-merge-2.0.0.tgz#94d24cf713d4a7a143653500ff4488a2d494681f"
+  integrity sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==
+
 object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
@@ -3103,6 +3188,13 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-imports-exports@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz#e3fb3b5e264cfb55c25b5dfcbe7f410f8dc4e7af"
+  integrity sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==
+  dependencies:
+    parse-statements "1.0.11"
+
 parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -3112,6 +3204,11 @@ parse-json@^5.0.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-statements@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/parse-statements/-/parse-statements-1.0.11.tgz#8787c5d383ae5746568571614be72b0689584344"
+  integrity sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -3299,6 +3396,11 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+reserved-identifiers@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz#d2982cd698e317dd3dced1ee1c52412dbd64fc64"
+  integrity sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -3438,7 +3540,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.6.0, semver@^7.7.1:
+semver@^7.6.0, semver@^7.7.1, semver@^7.7.4:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
@@ -3567,6 +3669,24 @@ source-map@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+spdx-exceptions@^2.1.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz#5d607d27fc806f66d7b64a766650fa890f04ed66"
+  integrity sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==
+
+spdx-expression-parse@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz#a23af9f3132115465dac215c099303e4ceac5794"
+  integrity sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.23"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz#b069e687b1291a32f126893ed76a27a745ee2133"
+  integrity sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==
 
 stable-hash@^0.0.5:
   version "0.0.5"
@@ -3735,6 +3855,14 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+to-valid-identifier@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz#27337955333c3c517feb60bea533cf27ce54b79f"
+  integrity sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==
+  dependencies:
+    "@sindresorhus/base62" "^1.0.0"
+    reserved-identifiers "^1.0.0"
 
 ts-api-utils@^1.3.0:
   version "1.4.3"


### PR DESCRIPTION
- Added 'eslint-plugin-jsdoc' to enforce JSDoc comments in TypeScript files.
- Updated ESLint configuration to include recommended rules for JSDoc.
- Enhanced type definitions across the codebase with detailed JSDoc comments for better clarity and maintainability.
- Improved documentation for various interfaces and props in the application.